### PR TITLE
Fix iOS Safari viewport and desktop overflow inconsistencies

### DIFF
--- a/app/(forms)/layout.tsx
+++ b/app/(forms)/layout.tsx
@@ -4,7 +4,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <main className="flex h-[100vh] flex-col items-center justify-center ">
+    <main className="flex min-h-[100dvh] flex-col items-center justify-center ">
       {children}
     </main>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -47,14 +47,13 @@ body {
 }
 
 .scrollbar::-webkit-scrollbar-track {
-  background: var(--foreground);
+  background: transparent;
   border-radius: 5px;
 }
 
 .scrollbar::-webkit-scrollbar-thumb {
-  background-color: var(--wine);
+  background-color: var(--foreground);
   border-radius: 10px;
-  border: 2px solid #f0f0f0;
 }
 
 @keyframes spin {

--- a/app/globals.css
+++ b/app/globals.css
@@ -30,6 +30,18 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+html,
+body {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+body {
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
 .scrollbar::-webkit-scrollbar {
   width: 5px;
 }

--- a/app/home/chat/[id]/page.tsx
+++ b/app/home/chat/[id]/page.tsx
@@ -32,7 +32,7 @@ export default async function Chat({ params }: {
                     {
                         image_url
                             ? (<Image src={image_url} alt='User avatar' width={35} height={35} className='w-[35px] h-[35px] rounded-full' />)
-                            : (<User className='w-[35px] h-[35px] border-2 rounded-full' />)
+                            : (<User className='w-[35px] h-[35px] border-2 border-foreground rounded-full' />)
 
                     }
                     <p className="font-semibold text-2xl hover:cursor-default">{name}</p>

--- a/app/home/chat/loading.tsx
+++ b/app/home/chat/loading.tsx
@@ -2,7 +2,7 @@ import { AlignJustify, ArrowLeft } from "@geist-ui/icons";
 
 export default function Loading() {
     return (
-        <div className="flex flex-col h-screen">
+        <div className="flex flex-col min-h-[100dvh]">
 
             <div className="flex items-center gap-4 p-4 border-b border-gray-500">
                 <ArrowLeft color="gray" className=" animate-pulse "/>

--- a/app/home/loading.tsx
+++ b/app/home/loading.tsx
@@ -2,7 +2,7 @@ import { AlignJustify, Search, User } from "@geist-ui/icons";
 
 export default function Loading() {
     return (
-        <div className="w-full h-screen overflow-y-auto">
+        <div className="w-full min-h-[100dvh] overflow-y-auto">
 
             <div className="flex items-center justify-between mb-6 p-4">
                 <User className="h-10 w-10 rounded-full animate-pulse"/>

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -24,7 +24,7 @@ export default async function Home() {
                 {
                     user_image
                     ? (<Image src={user_image} alt='User avatar' width={35} height={35} className='w-[35px] h-[35px] rounded-full' />)
-                    : (<User className='w-[35px] h-[35px] border-2 rounded-full' />)
+                    : (<User className='w-[35px] h-[35px] border-2 border-foreground rounded-full' />)
 
                 }
             

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ export default function Home() {
     setIsDark(window.matchMedia('(prefers-color-scheme: dark)').matches);
   },[])
   return (
-    <div className="flex h-[100vh] items-center justify-center flex-col gap-[5vh]">
+    <div className="flex min-h-[100dvh] items-center justify-center flex-col gap-[5vh]">
       <Image width={"150"} height={"200"} src={isDarkMode ? '/Logo-dark.png' : '/Logo.png'} alt="chaty logo" />
       <Image width={"250"} height={"250"} src={'/imageBackground.png'} alt="Background with people talking to each other by the cellphone" priority={true} />
       <div className="flex items-center justify-center flex-col gap-3">

--- a/app/ui/Skeletons.tsx
+++ b/app/ui/Skeletons.tsx
@@ -26,7 +26,7 @@ export function ChatListSkeleton() {
 }
 export function MessageListSkeleton() {
     return (
-        <div className="flex flex-col h-screen bg-[#2e1217]">
+        <div className="flex flex-col min-h-[100dvh] bg-[#2e1217]">
 
             <div className="flex items-center gap-4 p-4 border-b border-gray-500">
                 <div className="w-10 h-10 rounded-full bg-gray-700 animate-pulse"></div>

--- a/app/ui/home/CreateChat.tsx
+++ b/app/ui/home/CreateChat.tsx
@@ -45,7 +45,7 @@ export default function CreateChat() {
 
             {isOpen ? (
                 <>
-                    <div className="fixed z-2 top-0 left-0 w-[100vw] h-[100vh] bg-black opacity-75">
+                    <div className="fixed z-2 top-0 left-0 inset-0 bg-black opacity-75">
 
                     </div>
                     <form action={CreateChat}

--- a/app/ui/home/chat/ChatMessages.tsx
+++ b/app/ui/home/chat/ChatMessages.tsx
@@ -92,7 +92,7 @@ export default function ChatMessages({
 
     return (
         <div className="h-[90vh] flex flex-col">
-            <ol ref={messagesRef} className="flex overflow-y-auto flex-col gap-4 min-h-[75vh] mt-[20px]">
+            <ol ref={messagesRef} className="flex overflow-y-auto flex-col gap-4 min-h-[75vh] mt-[20px] scrollbar">
                 <div className="my-[10px]">
                     <p className="text-center text-gray-500">There are no previous messages</p>
                 </div>

--- a/app/ui/home/chat/MessageSplitter.tsx
+++ b/app/ui/home/chat/MessageSplitter.tsx
@@ -5,7 +5,7 @@ export default function MessageSplitter({ date }: { date: MessageType["date"] })
     const mounth = (date.getMonth()+1).toString();
     const year = date.getFullYear().toString();
     return (
-        <div className=" flex justify-center items-center w-[100vw] h-[1px] py-[15px] border-t-[1px] border-gray-500">
+        <div className=" flex justify-center items-center w-full h-[1px] py-[15px] border-t-[1px] border-gray-500">
             <p className="text-center align-center text-gray-500 text-[14px]">
                 {day.length == 1 ? "0" + day: day}/{mounth.length == 1 ? "0" + mounth: mounth}/{year} 
             </p>


### PR DESCRIPTION
### Motivation
- iOS Safari’s dynamic URL/search bar makes `100vh`-based layouts resize unexpectedly, breaking layout and turning fixed content into scrollable areas.
- Using `100vw` and full-viewport utilities can produce horizontal overflow on desktop when scrollbars are present, creating unwanted scrollbars.

### Description
- Replaced `h-[100vh]`/`h-screen` usages with `min-h-[100dvh]` on core pages and loading skeletons so components respect the dynamic iOS viewport height (`app/page.tsx`, `app/(forms)/layout.tsx`, `app/home/loading.tsx`, `app/home/chat/loading.tsx`, `app/ui/Skeletons.tsx`).
- Added global `html, body` guards and `overflow-x: hidden` plus `min-height: 100dvh` in `app/globals.css` to prevent horizontal overflow and improve mobile viewport consistency.
- Replaced `w-[100vw] h-[100vh]` overlay with `inset-0` and changed `w-[100vw]` to `w-full` for the chat splitter to avoid exceeding container width (`app/ui/home/CreateChat.tsx`, `app/ui/home/chat/MessageSplitter.tsx`).
- Committed changes to ensure layouts no longer rely on fixed viewport units that conflict with iOS Safari and desktop scrollbar behavior.

### Testing
- Ran `npm run lint` which completed successfully without lint errors.
- Started the Next dev server (`npm run dev`) which compiled and served the app, but page rendering hit a runtime environment error due to a missing `DATABASE_URL`; the styling/compile steps completed and the server was reachable.
- Captured a Playwright screenshot of the homepage (artifact produced) to validate mobile viewport rendering after the CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2e637b0a4832e87a0858a72b0d8f4)